### PR TITLE
Fix TCP/IP connection to Agilent 34410A

### DIFF
--- a/pyvisa-py/protocols/vxi11.py
+++ b/pyvisa-py/protocols/vxi11.py
@@ -197,13 +197,6 @@ class CoreClient(rpc.TCPClient):
         self.packer = Vxi11Packer()
         self.unpacker = Vxi11Unpacker('')
         super(CoreClient, self).__init__(host, DEVICE_CORE_PROG, DEVICE_CORE_VERS)
-        # I have disabled the creation of the socket by overriding connect.
-        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
-    def connect(self):
-        # Overrides connect method from parent class to avoid automatic
-        # opening of connection.
-        pass
 
     def create_link(self, id, lock_device, lock_timeout, name):
         params = (id, lock_device, lock_timeout, name)

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -91,7 +91,7 @@ class TCPIPSession(Session):
         else:
             term_char = 0
 
-        if self.term_char:
+        if hasattr(self, 'term_char') and self.term_char:
             flags = vxi11.OP_FLAG_TERMCHAR_SET
             term_char = str(self.term_char).encode('utf-8')[0]
 


### PR DESCRIPTION
Fixes minimal example

```python
#!/usr/bin/env python
import visa
rm = visa.ResourceManager('@py')
scope = rm.open_resource('TCPIP0::192.168.23.26::INSTR')
print scope.query("*IDN?")
```

to get the IDN string out of an Agilent 34410A via TCP/IP, which showed the following errors:

```
Traceback (most recent call last):
  File "./tcpip.py", line 6, in <module>
    scope = rm.open_resource('TCPIP0::192.168.23.26::INSTR')
  File "/usr/local/lib/python2.7/site-packages/pyvisa/highlevel.py", line 1638, in open_resource
    res.open(access_mode, open_timeout)
  File "/usr/local/lib/python2.7/site-packages/pyvisa/resources/resource.py", line 165, in open
    self.session, status = self._resource_manager.open_bare_resource(self._resource_name, access_mode, open_timeout)
  File "/usr/local/lib/python2.7/site-packages/pyvisa/highlevel.py", line 1602, in open_bare_resource
    return self.visalib.open(self.session, resource_name, access_mode, open_timeout)
  File "/usr/local/lib/python2.7/site-packages/pyvisa-py/highlevel.py", line 180, in open
    sess = cls(session, resource_name, parsed)
  File "/usr/local/lib/python2.7/site-packages/pyvisa-py/sessions.py", line 162, in __init__
    self.after_parsing()
  File "/usr/local/lib/python2.7/site-packages/pyvisa-py/tcpip.py", line 54, in after_parsing
    self.parsed['lan_device_name'])
  File "/usr/local/lib/python2.7/site-packages/pyvisa-py/protocols/vxi11.py", line 212, in create_link
    self.unpacker.unpack_create_link_resp)
  File "/usr/local/lib/python2.7/site-packages/pyvisa-py/protocols/rpc.py", line 238, in make_call
    self.do_call()
  File "/usr/local/lib/python2.7/site-packages/pyvisa-py/protocols/rpc.py", line 332, in do_call
    sendrecord(self.sock, call)
  File "/usr/local/lib/python2.7/site-packages/pyvisa-py/protocols/rpc.py", line 287, in sendrecord
    sendfrag(sock, 1, record)
  File "/usr/local/lib/python2.7/site-packages/pyvisa-py/protocols/rpc.py", line 283, in sendfrag
    sock.send(header + frag)
socket.error: [Errno 57] Socket is not connected
```

and

```
Traceback (most recent call last):
  File "./tcpip.py", line 7, in <module>
    print scope.query("*IDN?")
  File "/usr/local/lib/python2.7/site-packages/pyvisa/resources/messagebased.py", line 384, in query
    return self.read()
  File "/usr/local/lib/python2.7/site-packages/pyvisa/resources/messagebased.py", line 309, in read
    message = self.read_raw().decode(enco)
  File "/usr/local/lib/python2.7/site-packages/pyvisa/resources/messagebased.py", line 283, in read_raw
    chunk, status = self.visalib.read(self.session, size)
  File "/usr/local/lib/python2.7/site-packages/pyvisa-py/highlevel.py", line 297, in read
    return self.sessions[session].read(count)
  File "/usr/local/lib/python2.7/site-packages/pyvisa-py/tcpip.py", line 94, in read
    if self.term_char:
AttributeError: 'TCPIPSession' object has no attribute 'term_char'
```