### PR TITLE
Use pyvisa compat/struct.py for python < 2.7.8

### DIFF
--- a/pyvisa-py/protocols/rpc.py
+++ b/pyvisa-py/protocols/rpc.py
@@ -28,7 +28,7 @@ import sys
 import enum
 import xdrlib
 import socket
-import struct
+from pyvisa.compat import struct
 
 #: Version of the protocol
 RPCVERSION = 2

--- a/pyvisa-py/protocols/usbtmc.py
+++ b/pyvisa-py/protocols/usbtmc.py
@@ -17,7 +17,7 @@
 from __future__ import division, unicode_literals, print_function, absolute_import
 
 import enum
-import struct
+from pyvisa.compat import struct
 import time
 from collections import namedtuple
 


### PR DESCRIPTION
Use pyvisa.compat.struct instead of standard library struct module

resolves #30 