### PR TITLE
gpib.read() is already synchronous.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,8 +3,14 @@ pyvisa-py is written and maintained by Hernan E. Grecco <hernan.grecco@gmail.com
 
 Other contributors, listed alphabetically, are:
 
+* Alex Forencich <alex@alexforencich.com>
 * Alexander Bessman <bessman@kth.se>
+* Colin Marquardt <github@marquardt-home.de>
 * Lance McCulley <lancemcculley@gmail.com>
+* Martin Ritter <ritter@mpp.mpg.de>
+* Sebastian Held <sebastian.held@imst.de>
+* Thomas Kopp <20.kopp@gmail.com>
+* Thorsten Liebig <liebig@imst.de>
 * Tobias Müller <Tobias_Mueller@twam.info>
 
 (If you think that your name belongs here, please let the maintainer know)

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,12 @@ PyVISA-py Changelog
 ===================
 
 
+0.3 (unreleased)
+----------------
+
+- Nothing changed yet.
+
+
 0.2 (2015-08-25)
 ----------------
 

--- a/CHANGES
+++ b/CHANGES
@@ -5,11 +5,26 @@ PyVISA-py Changelog
 0.2 (unreleased)
 ----------------
 
+- Added support for TCPIP Socket.
+  (Issue #38, thanks Thorsten Liebig)
 - Added support for GPIB INSTR using linux-gpib.
   (Issue #24, thanks bessman)
 - Added support for USB RAW.
   (Issue #18, kopp)
-- Better error reporting.
+- Better error reporting when pyusb or pyserial is missing.
+- Fixed logging of unicode strings.
+  (Issue #54)
+- Fixed timeout in SerialSession.
+  (Issue #44)
+- Moved resource name parsing to PyVISA.
+- VXI11 protocol performance enhancement.
+  (thanks alexforencich)
+- Improved pyusb importing.
+- Fixed large binary reads in TCPIP.
+- Added backend information to logger.
+- Use pyvisa compat/struct.py for python < 2.7.8
+  (thanks Martin Ritter)
+
 
 
 0.1 (2015-02-08)

--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,7 @@ PyVISA-py Changelog
 ===================
 
 
-0.2 (unreleased)
+0.2 (2015-08-25)
 ----------------
 
 - Added support for TCPIP Socket.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,17 +75,10 @@ Now:
 - ASRL INSTR
 - USB INSTR
 - TCPIP INSTR
-
-Soon we will be supporting:
-
 - USB RAW
 - TCPIP SOCKET
-
-And later:
-
 - GPIB INSTR
 
-If you want that `soon` or `later` becomes now, give us a hand!
 
 
 Are all VISA attributes and methods implemented?

--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -111,15 +111,12 @@ class GPIBSession(Session):
         :rtype: bytes, constants.StatusCode
         """
 
-        try:
-            return self.interface.read(count), SUCCESS
+        # 0x2000 = 8192 = END
+        checker = lambda current: self.interface.ibsta() & 8192
 
-        except gpib.GpibError:
-            # 0x4000 = 16384 = TIMO
-            if self.interface.ibsta() & 16384:
-                return b'', StatusCode.error_timeout
-            else:
-                return b'', StatusCode.error_system_error
+        reader = lambda: self.interface.read(1)
+
+        return self._read(reader, count, checker, False, None, False, gpib.GpibError)
 
     def write(self, data):
         """Writes data to device or interface synchronously.
@@ -192,7 +189,7 @@ class GPIBSession(Session):
             else:
                 return constants.VI_FALSE, SUCCESS
 
-        elif attribute == constants.VI_ATTR_INTF_NUM:
+        elif Attribute == constants.VI_ATTR_INTF_NUM:
             # IbaBNA 0x200
             return self.interface.ask(512), SUCCESS
 

--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -15,7 +15,6 @@ from __future__ import division, unicode_literals, print_function, absolute_impo
 import warnings
 
 import random
-import re
 
 from pyvisa import constants, errors, highlevel, rname
 from pyvisa.compat import integer_types, OrderedDict
@@ -231,10 +230,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         resources = sum([st.list_resources()
                          for key, st in sessions.Session.iter_valid_session_classes()], [])
 
-        query = query.replace('?*', '.*')
-        matcher = re.compile(query, re.IGNORECASE)
-
-        resources = tuple(res for res in resources if matcher.match(res))
+        resources = rname.filter(resources, query)
 
         if resources:
             return resources

--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -47,16 +47,10 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         logger.debug('SerialSession was not imported %s.' % e)
 
     try:
-        from .usb import USBSession
-        logger.debug('USBSession was correctly imported.')
+        from .usb import USBSession, USBRawSession
+        logger.debug('USBSession and USBRawSession were correctly imported.')
     except ImportError as e:
-        logger.debug('USBSession was not imported %s.' % e)
-
-    try:
-        from .usb import USBRawSession
-        logger.debug('USBRawSession was correctly imported.')
-    except ImportError as e:
-        logger.debug('USBRawSession was not imported %s.' % e)
+        logger.debug('USBSession and USBRawSession were not imported %s.' % e)
 
     try:
         from .tcpip import TCPIPSession

--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -20,7 +20,7 @@ import re
 from pyvisa import constants, errors, highlevel, rname
 from pyvisa.compat import integer_types, OrderedDict
 
-from . import common, sessions
+from . import sessions
 from .common import logger
 
 
@@ -272,7 +272,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         :rtype: :class:`pyvisa.highlevel.ResourceInfo`, :class:`pyvisa.constants.StatusCode`
         """
         try:
-            parsed = common.parse_resource_name(resource_name)
+            parsed = rname.parse_resource_name(resource_name)
 
             return (highlevel.ResourceInfo(parsed.interface_type_const,
                                            parsed.board,

--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -331,7 +331,7 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
         except KeyError:
             return None, constants.StatusCode.error_invalid_object
 
-        return sess.get_attribute(attribute), constants.StatusCode.success
+        return sess.get_attribute(attribute)
 
     def set_attribute(self, session, attribute, attribute_state):
         """Sets the state of an attribute.

--- a/pyvisa-py/highlevel.py
+++ b/pyvisa-py/highlevel.py
@@ -247,40 +247,6 @@ class PyVisaLibrary(highlevel.VisaLibraryBase):
 
         raise errors.VisaIOError(errors.StatusCode.error_resource_not_found.value)
 
-    def parse_resource(self, session, resource_name):
-        """Parse a resource string to get the interface information.
-
-        Corresponds to viParseRsrc function of the VISA library.
-
-        :param session: Resource Manager session (should always be the Default Resource Manager for VISA
-                        returned from open_default_resource_manager()).
-        :param resource_name: Unique symbolic name of a resource.
-        :return: Resource information with interface type and board number, return value of the library call.
-        :rtype: :class:`pyvisa.highlevel.ResourceInfo`, :class:`pyvisa.constants.StatusCode`
-        """
-        return self.parse_resource_extended(session, resource_name)
-
-    def parse_resource_extended(self, session, resource_name):
-        """Parse a resource string to get extended interface information.
-
-        Corresponds to viParseRsrcEx function of the VISA library.
-
-        :param session: Resource Manager session (should always be the Default Resource Manager for VISA
-                        returned from open_default_resource_manager()).
-        :param resource_name: Unique symbolic name of a resource.
-        :return: Resource information, return value of the library call.
-        :rtype: :class:`pyvisa.highlevel.ResourceInfo`, :class:`pyvisa.constants.StatusCode`
-        """
-        try:
-            parsed = rname.parse_resource_name(resource_name)
-
-            return (highlevel.ResourceInfo(parsed.interface_type_const,
-                                           parsed.board,
-                                           parsed.resource_class, None, None),
-                    constants.StatusCode.success)
-        except ValueError:
-            return 0, constants.StatusCode.error_invalid_resource_name
-
     def read(self, session, count):
         """Reads data from device or interface synchronously.
 

--- a/pyvisa-py/protocols/rpc.py
+++ b/pyvisa-py/protocols/rpc.py
@@ -237,7 +237,7 @@ class Client(object):
 
     def make_call(self, proc, args, pack_func, unpack_func):
         # Don't normally override this (but see Broadcast)
-        logger.debug('Make call %r, %r, %r, %r', proc, args, str(pack_func), str(unpack_func))
+        logger.debug('Make call %r, %r, %r, %r', proc, args, pack_func, unpack_func)
 
         if pack_func is None and args is not None:
             raise TypeError('non-null args with null pack_func')
@@ -321,7 +321,7 @@ def recvrecord(sock):
         last, frag = recvfrag(sock)
         record = record + frag
 
-    logger.debug('Received record through %s: %s', sock, record)
+    logger.debug('Received record through %s: %r', sock, record)
 
     return record
 

--- a/pyvisa-py/protocols/vxi11.py
+++ b/pyvisa-py/protocols/vxi11.py
@@ -93,7 +93,7 @@ class Vxi11Packer(rpc.Packer):
         self.pack_int(id)
         self.pack_bool(lock_device)
         self.pack_uint(lock_timeout)
-        self.pack_string(device)
+        self.pack_string(device.encode('ascii'))
     
     def pack_device_write_parms(self, params):
         link, io_timeout, lock_timeout, flags, data = params

--- a/pyvisa-py/serial.py
+++ b/pyvisa-py/serial.py
@@ -74,10 +74,24 @@ class SerialSession(Session):
 
     @property
     def timeout(self):
-        return self.interface.timeout
+        value = self.interface.timeout
+
+        if value is None:
+            return constants.VI_TMO_INFINITE
+        elif value == 0:
+            return constants.VI_TMO_IMMEDIATE
+        else:
+            return int(value * 1000)
 
     @timeout.setter
     def timeout(self, value):
+        if value == constants.VI_TMO_INFINITE:
+            value = None
+        elif value == constants.VI_TMO_IMMEDIATE:
+            value = 0
+        else:
+            value = value / 1000.
+
         self.interface.timeout = value
         self.interface.writeTimeout = value
 

--- a/pyvisa-py/sessions.py
+++ b/pyvisa-py/sessions.py
@@ -15,7 +15,7 @@ from __future__ import division, unicode_literals, print_function, absolute_impo
 import abc
 import time
 
-from pyvisa import logger, constants, attributes, compat
+from pyvisa import logger, constants, attributes, compat, rname
 
 from . import common
 
@@ -163,11 +163,11 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
 
     def __init__(self, resource_manager_session, resource_name, parsed=None):
         if isinstance(resource_name, common.MockInterface):
-            parsed = common.parse_resource_name(resource_name.resource_name)
+            parsed = rname.parse_resource_name(resource_name.resource_name)
             parsed['mock'] = resource_name
 
         elif parsed is None:
-            parsed = common.parse_resource_name(resource_name)
+            parsed = rname.parse_resource_name(resource_name)
 
         self.parsed = parsed
 
@@ -178,9 +178,9 @@ class Session(compat.with_metaclass(abc.ABCMeta)):
         #: Values are get or set automatically by get_attribute and set_attribute
         #: Add your own by overriding after_parsing.
         self.attrs = {constants.VI_ATTR_RM_SESSION: resource_manager_session,
-                      constants.VI_ATTR_RSRC_NAME: parsed['canonical_resource_name'],
-                      constants.VI_ATTR_RSRC_CLASS: parsed['resource_class'],
-                      constants.VI_ATTR_INTF_TYPE: parsed['interface_type']}
+                      constants.VI_ATTR_RSRC_NAME: str(parsed),
+                      constants.VI_ATTR_RSRC_CLASS: parsed.resource_class,
+                      constants.VI_ATTR_INTF_TYPE: parsed.interface_type}
         self.after_parsing()
 
     def after_parsing(self):

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -387,7 +387,8 @@ class TCPIPSocketSession(Session):
                     constants.StatusCode.success_termination_character_read)
 
         while now - start <= timeout:
-	    select.select([self.interface], [], [])
+            # use select to wait for read ready
+            select.select([self.interface], [], [])
             last = read_fun(chunk_length)
 
             if not last:
@@ -430,6 +431,7 @@ class TCPIPSocketSession(Session):
             block = data[offset:min(offset+chunk_size, sz)]
 
             try:
+                # use select to wait for write ready
                 select.select([], [self.interface], [])
                 size = self.interface.send(block)
             except socket.timeout as e:

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -100,7 +100,7 @@ class TCPIPInstrSession(Session):
             flags = vxi11.OP_FLAG_TERMCHAR_SET
             term_char = str(term_char).encode('utf-8')[0]
 
-        read_data = b''
+        read_data = bytearray()
 
         end_reason = vxi11.RX_END | vxi11.RX_CHR
 
@@ -115,7 +115,7 @@ class TCPIPInstrSession(Session):
             if error:
                 return read_data, StatusCode.error_io
 
-            read_data += data
+            read_data.extend(data)
             count -= len(data)
 
             if count <= 0:
@@ -124,7 +124,7 @@ class TCPIPInstrSession(Session):
 
             chunk_length = min(count, chunk_length)
 
-        return read_data, status
+        return bytes(read_data), status
 
     def write(self, data):
         """Writes data to device or interface synchronously.

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -11,11 +11,14 @@
 """
 
 import random
+import socket
+import time
 
 from pyvisa import constants, attributes
 
 from .sessions import Session, UnknownAttribute
 from .protocols import vxi11
+from . import common
 
 
 StatusCode = constants.StatusCode
@@ -23,8 +26,9 @@ SUCCESS = StatusCode.success
 
 
 @Session.register(constants.InterfaceType.tcpip, 'INSTR')
-class TCPIPSession(Session):
-    """A TCPIP Session that uses the network standard library to do the low level communication.
+class TCPIPInstrSession(Session):
+    """A TCPIP Session that uses the network standard library to do the low level communication
+    using VXI-11
     """
 
     lock_timeout = 1000
@@ -305,3 +309,168 @@ class TCPIPSession(Session):
         if error:
             # TODO: Which message to return
             raise Exception("error unlocking: %d" % error)
+
+
+@Session.register(constants.InterfaceType.tcpip, 'SOCKET')
+class TCPIPSocketSession(Session):
+    """A TCPIP Session that uses the network standard library to do the low level communication.
+    """
+
+    lock_timeout = 1000
+    timeout = 1000
+
+    max_recv_size = 4096
+
+    # This buffer is used to store the bytes that appeared after termination char
+    _pending_buffer = b''
+
+    @staticmethod
+    def list_resources():
+        # TODO: is there a way to get this?
+        return []
+
+    def after_parsing(self):
+        # TODO: board_number not handled
+
+        self.interface = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        self.interface.setblocking(0)
+
+        try:
+            self.interface.connect((self.parsed.host_address, self.parsed.port))
+        except Exception as e:
+            raise Exception("could not create socket: %s" % e)
+
+        self.attrs[constants.VI_ATTR_TCPIP_ADDR] = self.parsed.host_address
+        self.attrs[constants.VI_ATTR_TCPIP_PORT] = self.parsed.port
+        self.attrs[constants.VI_ATTR_INTF_NUM] = self.parsed.board
+
+        for name in 'TERMCHAR,TERMCHAR_EN'.split(','):
+            attribute = getattr(constants, 'VI_ATTR_' + name)
+            self.attrs[attribute] = attributes.AttributesByID[attribute].default
+
+    def close(self):
+        self.interface.close()
+        self.interface = None
+
+    def read(self, count):
+        """Reads data from device or interface synchronously.
+
+        Corresponds to viRead function of the VISA library.
+
+        :param count: Number of bytes to be read.
+        :return: data read, return value of the library call.
+        :rtype: bytes, VISAStatus
+        """
+        if count < self.max_recv_size:
+            chunk_length = count
+        else:
+            chunk_length = self.max_recv_size
+
+        end_char, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR)
+        enabled, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR_EN)
+        timeout, _ = self.get_attribute(constants.VI_ATTR_TMO_VALUE)
+        timeout /= 1000
+
+        end_byte = common.int_to_byte(end_char) if end_char else b''
+
+        read_fun = self.socket.recv
+
+        now = start = time.time()
+
+        out = self._pending_buffer
+
+        if enabled and end_byte in out:
+            parts = out.split(end_byte)
+            self._pending_buffer = b''.join(parts[1:])
+            return (out + parts[0] + end_byte,
+                    constants.StatusCode.success_termination_character_read)
+
+        while now - start <= timeout:
+            last = read_fun(chunk_length)
+
+            if not last:
+                time.sleep(.01)
+                now = time.time()
+                continue
+
+            if enabled and end_byte in last:
+                parts = last.split(end_byte)
+                self._pending_buffer = b''.join(parts[1:])
+                return (out + parts[0] + end_byte,
+                        constants.StatusCode.success_termination_character_read)
+
+            out += last
+
+            if len(out) == count:
+                return out, constants.StatusCode.success_max_count_read
+        else:
+            return out, constants.StatusCode.error_timeout
+
+    def write(self, data):
+        """Writes data to device or interface synchronously.
+
+        Corresponds to viWrite function of the VISA library.
+
+        :param data: data to be written.
+        :type data: str
+        :return: Number of bytes actually transferred, return value of the library call.
+        :rtype: int, VISAStatus
+        """
+
+        chunk_size = 4096
+
+        num = sz = len(data)
+
+        offset = 0
+
+        while num > 0:
+
+            block = data[offset:min(offset+chunk_size, sz)]
+
+            try:
+                size = self.socket.send(block)
+            except socket.timeout as e:
+                return offset, StatusCode.error_io
+
+            if size < len(block):
+                return offset, StatusCode.error_io
+
+            offset += size
+            num -= size
+
+        return offset, SUCCESS
+
+    def _get_attribute(self, attribute):
+        """Get the value for a given VISA attribute for this session.
+
+        Use to implement custom logic for attributes.
+
+        :param attribute: Resource attribute for which the state query is made
+        :return: The state of the queried attribute for a specified resource, return value of the library call.
+        :rtype: (unicode | str | list | int, VISAStatus)
+        """
+
+        if attribute == constants.VI_ATTR_TCPIP_HOSTNAME:
+            raise NotImplementedError
+
+        elif attribute == constants.VI_ATTR_TCPIP_KEEPALIVE:
+            raise NotImplementedError
+
+        elif attribute == constants.VI_ATTR_TCPIP_NODELAY:
+            raise NotImplementedError
+
+        raise UnknownAttribute(attribute)
+
+    def _set_attribute(self, attribute, attribute_state):
+        """Sets the state of an attribute.
+
+        Corresponds to viSetAttribute function of the VISA library.
+
+        :param attribute: Attribute for which the state is to be modified. (Attributes.*)
+        :param attribute_state: The state of the attribute to be set for the specified object.
+        :return: return value of the library call.
+        :rtype: VISAStatus
+        """
+
+        raise UnknownAttribute(attribute)

--- a/pyvisa-py/tcpip.py
+++ b/pyvisa-py/tcpip.py
@@ -101,6 +101,8 @@ class TCPIPSession(Session):
 
         read_fun = self.interface.device_read
 
+        status = SUCCESS
+
         while reason & end_reason == 0:
             error, reason, data = read_fun(self.link, chunk_length, self.timeout,
                                            self.lock_timeout, flags, term_char)
@@ -112,11 +114,12 @@ class TCPIPSession(Session):
             count -= len(data)
 
             if count <= 0:
+                status = StatusCode.success_max_count_read
                 break
 
             chunk_length = min(count, chunk_length)
 
-        return read_data, SUCCESS
+        return read_data, status
 
     def write(self, data):
         """Writes data to device or interface synchronously.

--- a/pyvisa-py/usb.py
+++ b/pyvisa-py/usb.py
@@ -27,6 +27,22 @@ except ImportError as e:
                                  'Please install PyUSB to use this resource type.\n%s' % e)
     raise
 
+try:
+    _ = usb.core.find()
+except ValueError as e:
+    msg = 'PyUSB does not seem to be properly installed.\n' \
+          'Please refer to PyUSB documentation and ' \
+          'install a suitable backend like ' \
+          'libusb 0.1, libusb 1.0, libusbx, ' \
+          'libusb-win32 or OpenUSB\%s' % e
+
+    Session.register_unavailable(constants.InterfaceType.usb, 'INSTR', msg)
+
+    Session.register_unavailable(constants.InterfaceType.usb, 'RAW', msg)
+
+    raise
+
+
 from . import common
 
 StatusCode = constants.StatusCode

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if sys.version_info < (2, 7):
 
 setup(name='PyVISA-py',
       description='Python VISA bindings for GPIB, RS232, and USB instruments',
-      version='0.2',
+      version='0.3.dev0',
       long_description=long_description,
       author='Hernan E. Grecco',
       author_email='hernan.grecco@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -28,14 +28,14 @@ long_description = '\n\n'.join([read('README'),
 
 __doc__ = long_description
 
-requirements = ['pyvisa>=1.6.3']
+requirements = ['pyvisa>=1.7']
 
 if sys.version_info < (2, 7):
     requirements.append('importlib')
 
 setup(name='PyVISA-py',
       description='Python VISA bindings for GPIB, RS232, and USB instruments',
-      version='0.2.dev0',
+      version='0.2.dev2',
       long_description=long_description,
       author='Hernan E. Grecco',
       author_email='hernan.grecco@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ long_description = '\n\n'.join([read('README'),
 
 __doc__ = long_description
 
-requirements = ['pyvisa>=1.7']
+requirements = ['pyvisa>=1.8']
 
 if sys.version_info < (2, 7):
     requirements.append('importlib')

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if sys.version_info < (2, 7):
 
 setup(name='PyVISA-py',
       description='Python VISA bindings for GPIB, RS232, and USB instruments',
-      version='0.2.dev2',
+      version='0.2',
       long_description=long_description,
       author='Hernan E. Grecco',
       author_email='hernan.grecco@gmail.com',


### PR DESCRIPTION
Turns out reading one byte at a time can cause timeout problems with certain interfaces. A NI-GPIB-USB-B adapter, for example, takes roughly two seconds to respond to *any* read operation, regardless of how many bytes are read. Reading 50 bytes one at a time would therefore take 100 seconds, unless it timed out first.

Luckily, linux-gpib reads synchronously anyway so there is no need to read one byte at a time.