### PR TITLE
USB TMC fixes

### DIFF
--- a/pyvisa-py/usb.py
+++ b/pyvisa-py/usb.py
@@ -93,9 +93,9 @@ class USBSession(Session):
         term_char, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR)
         term_char_en, _ = self.get_attribute(constants.VI_ATTR_TERMCHAR_EN)
 
-        return self._read(lambda: self.interface.read(1),
+        return self._read(lambda: self.interface.read(count),
                           count,
-                          lambda current: False,
+                          lambda current: True, # USB always returns a complete message
                           supress_end_en,
                           term_char,
                           term_char_en,


### PR DESCRIPTION
These patches fix the slow responses from USB devices (#48).
The USB code always returned a complete message, but the code in session.py only expected a single byte. Now the code handles the complete message, because returning single bytes from USB would be very inefficient. 

Tested with python 2.7 and 3.4 using a Keysight 34461A multimeter. 