### PR TITLE
Speed up large transfers over GPIB

### DIFF
--- a/pyvisa-py/gpib.py
+++ b/pyvisa-py/gpib.py
@@ -123,7 +123,7 @@ class GPIBSession(Session):
         # 0x2000 = 8192 = END
         checker = lambda current: self.interface.ibsta() & 8192
 
-        reader = lambda: self.interface.read(1)
+        reader = lambda: self.interface.read(count)
 
         return self._read(reader, count, checker, False, None, False, gpib.GpibError)
 


### PR DESCRIPTION
Reading one byte at a time from linux-gpib can be very slow. This change
passes the read count directly to linux-gpib, making large transfers
much faster.